### PR TITLE
Delay updating finishTime if updating hasn't finished

### DIFF
--- a/controllers/cassandrarestore_controller.go
+++ b/controllers/cassandrarestore_controller.go
@@ -97,7 +97,7 @@ func (r *CassandraRestoreReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 			}
 		}
 
-		if isCassdcReady(cassdc) && cassdc.Status.LastServerNodeStarted.After(restore.Status.StartTime.Time) {
+		if isCassdcReady(cassdc) && wasCassdcUpdated(restore.Status.StartTime.Time, cassdc) {
 			r.Log.Info("the cassandradatacenter has been restored and is ready", "CassandraDatacenter", cassdcKey)
 
 			patch := client.MergeFrom(restore.DeepCopy())
@@ -279,13 +279,21 @@ func getEnvVarIndex(name string, envVars []corev1.EnvVar) int {
 	return -1
 }
 
+func wasCassdcUpdated(startTime time.Time, cassdc *cassdcapi.CassandraDatacenter) bool {
+	updateCondition, found := cassdc.GetCondition(cassdcapi.DatacenterUpdating)
+	if !found || updateCondition.Status != corev1.ConditionFalse {
+		return false
+	}
+	return updateCondition.LastTransitionTime.After(startTime)
+}
+
 func isCassdcReady(cassdc *cassdcapi.CassandraDatacenter) bool {
 	if cassdc.Status.CassandraOperatorProgress != cassdcapi.ProgressReady {
 		return false
 	}
-	statusUpdating := cassdc.GetConditionStatus(cassdcapi.DatacenterUpdating)
+
 	statusReady := cassdc.GetConditionStatus(cassdcapi.DatacenterReady)
-	return statusReady == corev1.ConditionTrue && statusUpdating == corev1.ConditionFalse
+	return statusReady == corev1.ConditionTrue
 }
 
 func (r *CassandraRestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
Verify that the Updating status has been reset back to false and at the same time verify that lastServerNodeStarted has time after the restore started (to ensure cass-operator was able to pick up the update request). Fixes https://github.com/k8ssandra/k8ssandra/issues/192