### PR TITLE
Refactor restore code and avoid rolling restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,9 @@ docker-build:
 	docker build . -t ${REV_IMAGE}
 	docker tag ${REV_IMAGE} ${LATEST_IMAGE}
 
+kind-docker-load:
+	kind load docker-image k8ssandra/medusa-operator:latest
+
 # Push the docker image
 docker-push:
 	docker push ${REV_IMAGE}

--- a/api/v1alpha1/cassandrarestore_types.go
+++ b/api/v1alpha1/cassandrarestore_types.go
@@ -56,6 +56,8 @@ type CassandraRestoreStatus struct {
 
 	FinishTime metav1.Time `json:"finishTime,omitempty"`
 
+	DatacenterStopped metav1.Time `json:"datacenterStopped,omitempty"`
+
 	InProgress []string `json:"inProgress,omitempty"`
 
 	Finished []string `json:"finished,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -247,6 +247,7 @@ func (in *CassandraRestoreStatus) DeepCopyInto(out *CassandraRestoreStatus) {
 	*out = *in
 	in.StartTime.DeepCopyInto(&out.StartTime)
 	in.FinishTime.DeepCopyInto(&out.FinishTime)
+	in.DatacenterStopped.DeepCopyInto(&out.DatacenterStopped)
 	if in.InProgress != nil {
 		in, out := &in.InProgress, &out.InProgress
 		*out = make([]string, len(*in))

--- a/config/crd/bases/cassandra.k8ssandra.io_cassandrarestores.yaml
+++ b/config/crd/bases/cassandra.k8ssandra.io_cassandrarestores.yaml
@@ -62,6 +62,9 @@ spec:
           status:
             description: CassandraRestoreStatus defines the observed state of CassandraRestore
             properties:
+              datacenterStopped:
+                format: date-time
+                type: string
               failed:
                 items:
                   type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - list
+- apiGroups:
   - cassandra.datastax.com
   resources:
   - cassandradatacenters
@@ -24,6 +30,7 @@ rules:
   - create
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,7 @@ rules:
   - statefulsets
   verbs:
   - list
+  - watch
 - apiGroups:
   - cassandra.datastax.com
   resources:

--- a/controllers/cassandrarestore_controller.go
+++ b/controllers/cassandrarestore_controller.go
@@ -18,28 +18,29 @@ package controllers
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
-	"k8s.io/kubernetes/pkg/util/hash"
+	"github.com/k8ssandra/medusa-operator/pkg/cassandra"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"time"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/google/uuid"
 	cassdcapi "github.com/k8ssandra/cass-operator/operator/pkg/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/medusa-operator/api/v1alpha1"
+	"github.com/k8ssandra/medusa-operator/pkg/reconcile"
 )
 
 const (
 	restoreContainerName = "medusa-restore"
+	backupNameEnvVar     = "BACKUP_NAME"
+	restoreKeyEnvVar     = "RESTORE_KEY"
 )
 
 // CassandraRestoreReconciler reconciles a CassandraRestore object
@@ -52,220 +53,170 @@ type CassandraRestoreReconciler struct {
 // +kubebuilder:rbac:groups=cassandra.k8ssandra.io,namespace="medusa-operator",resources=cassandrarestores,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cassandra.k8ssandra.io,namespace="medusa-operator",resources=cassandrarestores/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=cassandra.k8ssandra.io,namespace="medusa-operator",resources=cassandrarebackups,verbs=get;list;watch
-// +kubebuilder:rbac:groups=cassandra.datastax.com,namespace="medusa-operator",resources=cassandradatacenters,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=cassandra.datastax.com,namespace="medusa-operator",resources=cassandradatacenters,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=apps,namespace="medusa-operator",resources=statefulsets,verbs=list;watch
 
 func (r *CassandraRestoreReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
-	_ = r.Log.WithValues("cassandrarestore", req.NamespacedName)
 
-	instance := &api.CassandraRestore{}
-	err := r.Get(ctx, req.NamespacedName, instance)
+	factory := reconcile.NewFactory(r.Client, r.Log)
+	request, result, err := factory.NewRestoreRequest(ctx, req.NamespacedName)
+
+	if result != nil {
+		return *result, err
+	}
+
+	request.SetRestoreStartTime(metav1.Now())
+	request.SetRestoreKey(uuid.New().String())
+
+	if request.Restore.Spec.Shutdown && request.Restore.Status.DatacenterStopped.IsZero() {
+		if stopped := stopDatacenter(request); !stopped {
+			return r.applyUpdatesAndRequeue(ctx, request)
+		}
+	}
+
+	if err := updateRestoreInitContainer(request); err != nil {
+		request.Log.Error(err, "The datacenter is not properly configured for backup/restore")
+		// No need to requeue here because the datacenter is not properly configured for
+		// backup/restore with Medusa.
+		return ctrl.Result{}, err
+	}
+
+	complete, err := r.podTemplateSpecUpdateComplete(ctx, request)
+
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
+		request.Log.Error(err, "Failed to check if datacenter update is complete")
+		// Not going to bother applying updates here since we hit an error.
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
 	}
 
-	restore := instance.DeepCopy()
-
-	if len(restore.Status.RestoreKey) == 0 {
-		if err = r.setRestoreKey(ctx, restore); err != nil {
-			// Could be stale item, we'll just requeue - this process can be repeated
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-		}
+	if !complete {
+		request.Log.Info("Waiting for datacenter update to complete")
+		return r.applyUpdatesAndRequeue(ctx, request)
 	}
 
-	// See if the restore is already in progress
-	if !restore.Status.StartTime.IsZero() {
-		cassdcKey := types.NamespacedName{Namespace: req.Namespace, Name: restore.Spec.CassandraDatacenter.Name}
-		cassdc := &cassdcapi.CassandraDatacenter{}
+	request.Log.Info("The datacenter has been updated")
 
-		if err = r.Get(ctx, cassdcKey, cassdc); err != nil {
-			// TODO add some additional logging and/or generate an event if the error is not found
-			if errors.IsNotFound(err) {
-				r.Log.Error(err, "cassandradatacenter not found", "CassandraDatacenter", cassdcKey)
+	if request.Datacenter.Spec.Stopped {
+		request.Log.Info("Starting the datacenter")
+		request.Datacenter.Spec.Stopped = false
 
-				patch := client.MergeFrom(restore.DeepCopy())
-				restore.Status.FinishTime = metav1.Now()
-				if err = r.Status().Patch(ctx, restore, patch); err == nil {
-					return ctrl.Result{Requeue: false}, err
-				} else {
-					r.Log.Error(err, "failed to patch status with end time")
-					return ctrl.Result{RequeueAfter: 5 * time.Second}, err
-				}
-			} else {
-				r.Log.Error(err, "failed to get cassandradatacenter", "CassandraDatacenter", cassdcKey)
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, err
-			}
-		}
-
-		if isCassdcReady(cassdc) && wasCassdcUpdated(restore.Status.StartTime.Time, cassdc) {
-			r.Log.Info("the cassandradatacenter has been restored and is ready", "CassandraDatacenter", cassdcKey)
-
-			patch := client.MergeFrom(restore.DeepCopy())
-			restore.Status.FinishTime = metav1.Now()
-			if err = r.Status().Patch(ctx, restore, patch); err == nil {
-				return ctrl.Result{Requeue: false}, err
-			} else {
-				r.Log.Error(err, "failed to patch status with end time")
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, err
-			}
-		}
-
-		// TODO handle scenarios in which the CassandraDatacenter fails to become ready
-
-		r.Log.Info("waiting for CassandraDatacenter to come online", "CassandraDatacenter", cassdcKey)
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		return r.applyUpdatesAndRequeue(ctx, request)
 	}
 
-	backupKey := types.NamespacedName{Namespace: req.Namespace, Name: restore.Spec.Backup}
-	backup := &api.CassandraBackup{}
+	if !cassandra.DatacenterReady(request.Datacenter) {
+		request.Log.Info("Waiting for datacenter to come back online")
+		return r.applyUpdatesAndRequeue(ctx, request)
+	}
 
-	if err = r.Get(ctx, backupKey, backup); err != nil {
-		// TODO add some additional logging and/or generate an event if the error is not found
-		r.Log.Error(err, "failed to get backup", "CassandraBackup", backupKey)
+	request.SetRestoreFinishTime(metav1.Now())
+	if err := r.applyUpdates(ctx, request); err != nil {
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
 	}
 
-	if restore.Spec.InPlace {
-		r.Log.Info("performing in place restore")
-
-		cassdcKey := types.NamespacedName{Namespace: req.Namespace, Name: restore.Spec.CassandraDatacenter.Name}
-		cassdc := &cassdcapi.CassandraDatacenter{}
-
-		if err = r.Get(ctx, cassdcKey, cassdc); err != nil {
-			r.Log.Error(err, "failed to get cassandradatacenter", "CassandraDatacenter", cassdcKey)
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, err
-		}
-
-		cassdc = cassdc.DeepCopy()
-
-		if restore.Spec.Shutdown {
-			if cassdc.Spec.Stopped {
-				// If cass-operator hasn't finished shutting down all the pods, requeue and check later again
-				podList := &corev1.PodList{}
-				r.List(ctx, podList, client.InNamespace(req.Namespace), client.MatchingLabels(map[string]string{"cassandra.datastax.com/datacenter": restore.Spec.CassandraDatacenter.Name}))
-
-				if len(podList.Items) > 0 {
-					// Some pods have not been shutdown yet
-					return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-				}
-			} else {
-				cassdc.Spec.Stopped = true
-				// Patch it
-				if err = r.Update(ctx, cassdc); err != nil {
-					r.Log.Error(err, "failed to update the cassandradatacenter", "CassandraDatacenter", cassdcKey)
-					return ctrl.Result{RequeueAfter: 10 * time.Second}, err
-				}
-
-				// Wait for next time if it's ready
-				r.Log.Info("the cassandradatacenter has been updated and will be shutdown", "CassandraDatacenter", cassdcKey)
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-			}
-		}
-
-		beforeHash := deepHashString(cassdc.Spec.PodTemplateSpec)
-
-		if err = setBackupNameInRestoreContainer(backup.Spec.Name, cassdc); err != nil {
-			r.Log.Error(err, "failed to set backup name in restore container", "CassandraDatacenter", cassdcKey)
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, err
-		}
-
-		if err = setRestoreKeyInRestoreContainer(restore.Status.RestoreKey, cassdc); err != nil {
-			r.Log.Error(err, "failed to set restore key in restore container", "CassandraDatacenter", cassdcKey)
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, err
-		}
-
-		afterHash := deepHashString(cassdc.Spec.PodTemplateSpec)
-
-		if restore.Spec.Shutdown {
-			// cass-operator does not apply updates to the StatefulSet's template spec until
-			// pods are ready. This means that when we shutdown and update the template spec
-			// with the backup name and the restore key, cass-operator first scales the
-			// StatefulSet back up and then only after the pods are ready does it update the
-			// template spec. This results in a StatefulSet update which has the effect of a
-			// cluster rolling restart. The following if block is a work around to avoid that
-			// rolling restart.
-			if beforeHash != afterHash {
-				racks := make([]string, 0, len(cassdc.Spec.Racks))
-				for _, rack := range cassdc.Spec.Racks {
-					racks = append(racks, rack.Name)
-				}
-				cassdc.Spec.ForceUpgradeRacks = racks
-
-				r.Log.Info("updating racks", "CassandraDatacenter", cassdcKey, "Racks", cassdc.Spec.ForceUpgradeRacks)
-
-				if err = r.Update(ctx, cassdc); err == nil {
-					return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-				}
-
-				r.Log.Error(err, "failed to force update racks", "CassandraDatacenter", cassdcKey)
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, err
-			}
-
-			if isCassdcUpdating(cassdc) {
-				r.Log.Info("waiting for rack updates to complete", "CassandraDatacenter", cassdcKey)
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-			}
-		}
-
-		patch := client.MergeFromWithOptions(restore.DeepCopy(), client.MergeFromWithOptimisticLock{})
-		restore.Status.StartTime = metav1.Now()
-		if err = r.Status().Patch(ctx, restore, patch); err != nil {
-			r.Log.Error(err, "fail to patch status with start time")
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
-		}
-
-		if restore.Spec.Shutdown {
-			// Restart the cluster
-			cassdc.Spec.Stopped = false
-			r.Log.Info("restarting the CassandraDatacenter", "CassandraDatacenter", cassdcKey)
-		}
-
-		if err = r.Update(ctx, cassdc); err == nil {
-			r.Log.Info("the cassandradatacenter has been updated and will be restarted", "CassandraDatacenter", cassdcKey)
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, err
-		} else {
-			r.Log.Error(err, "failed to update the cassandradatacenter", "CassandraDatacenter", cassdcKey)
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, err
-		}
-	}
-
-	r.Log.Info("restoring to new cassandradatacenter")
-
-	newCassdc, err := buildNewCassandraDatacenter(restore, backup)
-	if err != nil {
-		r.Log.Error(err, "failed to build new cassandradatacenter")
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
-	}
-
-	cassdcKey := types.NamespacedName{Namespace: newCassdc.Namespace, Name: newCassdc.Name}
-
-	r.Log.Info("creating new cassandradatacenter", "CassandraDatacenter", cassdcKey)
-
-	if err = r.Create(ctx, newCassdc); err == nil {
-		patch := client.MergeFrom(restore.DeepCopy())
-		restore.Status.StartTime = metav1.Now()
-		if err = r.Status().Patch(ctx, restore, patch); err != nil {
-			r.Log.Error(err, "fail to patch status with start time")
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
-		} else {
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, err
-		}
-	} else {
-		r.Log.Error(err, "failed to create cassandradatacenter", "CassandraDatacenter", cassdcKey)
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-	}
+	request.Log.Info("The restore operation is complete")
+	return ctrl.Result{}, nil
 }
 
-func (r *CassandraRestoreReconciler) setRestoreKey(ctx context.Context, restore *api.CassandraRestore) error {
-	key := uuid.New()
-	patch := client.MergeFromWithOptions(restore.DeepCopy(), client.MergeFromWithOptimisticLock{})
-	restore.Status.RestoreKey = key.String()
+// applyUpdates patches the CassandraDatacenter if its spec has been updated and patches
+// the CassandraRestore if its status has been updated.
+func (r *CassandraRestoreReconciler) applyUpdates(ctx context.Context, req *reconcile.RestoreRequest) error {
+	if req.DatacenterModified() {
+		if err := r.Patch(ctx, req.Datacenter, req.GetDatacenterPatch()); err != nil {
+			if errors.IsResourceExpired(err) {
+				req.Log.Info("CassandraDatacenter version expired!")
+			}
+			req.Log.Error(err, "Failed to patch the CassandraDatacenter")
+			return err
+		}
+	}
 
-	return r.Status().Patch(ctx, restore, patch)
+	if req.RestoreModified() {
+		if err := r.Status().Patch(ctx, req.Restore, req.GetRestorePatch()); err != nil {
+			req.Log.Error(err, "Failed to patch the CassandraRestore")
+			return err
+		}
+	}
+
+	return nil
 }
+
+func (r *CassandraRestoreReconciler) applyUpdatesAndRequeue(ctx context.Context, req *reconcile.RestoreRequest) (ctrl.Result, error) {
+	if err := r.applyUpdates(ctx, req); err != nil {
+		req.Log.Error(err, "Failed to apply updates")
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
+	}
+	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+}
+
+// updateRestoreInitContainer sets the backup name and restore key env vars in the restore
+// init container. An error is returned if the container is not found.
+func updateRestoreInitContainer(req *reconcile.RestoreRequest) error {
+	if err := setBackupNameInRestoreContainer(req.Backup.Spec.Name, req.Datacenter); err != nil {
+		return err
+	}
+	return setRestoreKeyInRestoreContainer(req.Restore.Status.RestoreKey, req.Datacenter)
+}
+
+// podTemplateSpecUpdateComplete checks that the pod template spec changes, namely the ones
+// with the restore container, have been pushed down to the StatefulSets. Return true if
+// the changes have been applied.
+func (r *CassandraRestoreReconciler) podTemplateSpecUpdateComplete(ctx context.Context, req *reconcile.RestoreRequest) (bool, error) {
+	if updated := cassandra.DatacenterUpdatedAfter(req.Restore.Status.DatacenterStopped.Time, req.Datacenter); !updated {
+		return false, nil
+	}
+
+	// It may not be sufficient to check for the update only via status conditions. We will
+	// check the template spec of the StatefulSets to be certain that the update has been
+	// applied. We do this in order to avoid an extra rolling restart after the
+	// StatefulSets are scaled back up.
+
+	statefulsetList := &appsv1.StatefulSetList{}
+	labels := client.MatchingLabels{cassdcapi.ClusterLabel: req.Datacenter.Spec.ClusterName, cassdcapi.DatacenterLabel: req.Datacenter.Name}
+
+	if err := r.List(ctx, statefulsetList, labels); err != nil {
+		req.Log.Error(err, "Failed to get StatefulSets")
+		return false, err
+	}
+
+	for _, statefulset := range statefulsetList.Items {
+		container := getRestoreInitContainerFromStatefulSet(&statefulset)
+
+		if container == nil {
+			return false, nil
+		}
+
+		if !containerHasEnvVar(container, backupNameEnvVar, req.Backup.Spec.Name) {
+			return false, nil
+		}
+
+		if !containerHasEnvVar(container, restoreKeyEnvVar, req.Restore.Status.RestoreKey) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// stopDatacenter sets the Stopped property in the Datacenter spec to true. Returns true if
+// the datacenter is stopped.
+func stopDatacenter(req *reconcile.RestoreRequest) bool {
+	if cassandra.DatacenterStopped(req.Datacenter) {
+		req.Log.Info("The datacenter is stopped", "Status", req.Datacenter.Status)
+		req.SetDatacenterStoppedTime(metav1.Now())
+		return true
+	}
+
+	if cassandra.DatacenterStopping(req.Datacenter) {
+		req.Log.Info("Waiting for datacenter to stop")
+		return false
+	}
+
+	req.Log.Info("Stopping datacenter")
+	req.Datacenter.Spec.Stopped = true
+	return false
+}
+
 
 func buildNewCassandraDatacenter(restore *api.CassandraRestore, backup *api.CassandraBackup) (*cassdcapi.CassandraDatacenter, error) {
 	newCassdc := &cassdcapi.CassandraDatacenter{
@@ -295,40 +246,40 @@ func setBackupNameInRestoreContainer(backupName string, cassdc *cassdcapi.Cassan
 
 	restoreContainer := &cassdc.Spec.PodTemplateSpec.Spec.InitContainers[index]
 	envVars := restoreContainer.Env
-	envVarIdx := getEnvVarIndex("BACKUP_NAME", envVars)
+	envVarIdx := getEnvVarIndex(backupNameEnvVar, envVars)
 
 	if envVarIdx > -1 {
 		envVars[envVarIdx].Value = backupName
 	} else {
-		envVars = append(envVars, corev1.EnvVar{Name: "BACKUP_NAME", Value: backupName})
+		envVars = append(envVars, corev1.EnvVar{Name: backupNameEnvVar, Value: backupName})
 	}
 	restoreContainer.Env = envVars
 
 	return nil
 }
 
-func setRestoreKeyInRestoreContainer(restoreKey string, cassdc *cassdcapi.CassandraDatacenter) error {
-	index, err := getRestoreInitContainerIndex(cassdc)
+func setRestoreKeyInRestoreContainer(restoreKey string, dc *cassdcapi.CassandraDatacenter) error {
+	index, err := getRestoreInitContainerIndex(dc)
 	if err != nil {
 		return err
 	}
 
-	restoreContainer := &cassdc.Spec.PodTemplateSpec.Spec.InitContainers[index]
+	restoreContainer := &dc.Spec.PodTemplateSpec.Spec.InitContainers[index]
 	envVars := restoreContainer.Env
-	envVarIdx := getEnvVarIndex("RESTORE_KEY", envVars)
+	envVarIdx := getEnvVarIndex(restoreKeyEnvVar, envVars)
 
 	if envVarIdx > -1 {
 		envVars[envVarIdx].Value = restoreKey
 	} else {
-		envVars = append(envVars, corev1.EnvVar{Name: "RESTORE_KEY", Value: restoreKey})
+		envVars = append(envVars, corev1.EnvVar{Name: restoreKeyEnvVar, Value: restoreKey})
 	}
 	restoreContainer.Env = envVars
 
 	return nil
 }
 
-func getRestoreInitContainerIndex(cassdc *cassdcapi.CassandraDatacenter) (int, error) {
-	spec := cassdc.Spec.PodTemplateSpec
+func getRestoreInitContainerIndex(dc *cassdcapi.CassandraDatacenter) (int, error) {
+	spec := dc.Spec.PodTemplateSpec
 	initContainers := &spec.Spec.InitContainers
 
 	for i, container := range *initContainers {
@@ -340,6 +291,16 @@ func getRestoreInitContainerIndex(cassdc *cassdcapi.CassandraDatacenter) (int, e
 	return 0, fmt.Errorf("restore initContainer (%s) not found", restoreContainerName)
 }
 
+func containerHasEnvVar(container *corev1.Container, name, value string) bool {
+	idx := getEnvVarIndex(name, container.Env)
+
+	if idx < 0 {
+		return false
+	}
+
+	return container.Env[idx].Value == value
+}
+
 func getEnvVarIndex(name string, envVars []corev1.EnvVar) int {
 	for i, envVar := range envVars {
 		if envVar.Name == name {
@@ -349,26 +310,13 @@ func getEnvVarIndex(name string, envVars []corev1.EnvVar) int {
 	return -1
 }
 
-func wasCassdcUpdated(startTime time.Time, cassdc *cassdcapi.CassandraDatacenter) bool {
-	updateCondition, found := cassdc.GetCondition(cassdcapi.DatacenterUpdating)
-	if !found || updateCondition.Status != corev1.ConditionFalse {
-		return false
+func getRestoreInitContainerFromStatefulSet(statefulset *appsv1.StatefulSet) *corev1.Container {
+	for _, container := range statefulset.Spec.Template.Spec.InitContainers {
+		if container.Name == restoreContainerName {
+			return &container
+		}
 	}
-	return updateCondition.LastTransitionTime.After(startTime)
-}
-
-func isCassdcReady(cassdc *cassdcapi.CassandraDatacenter) bool {
-	if cassdc.Status.CassandraOperatorProgress != cassdcapi.ProgressReady {
-		return false
-	}
-
-	statusReady := cassdc.GetConditionStatus(cassdcapi.DatacenterReady)
-	return statusReady == corev1.ConditionTrue
-}
-
-func isCassdcUpdating(cassdc *cassdcapi.CassandraDatacenter) bool {
-	statusUpdating := cassdc.GetConditionStatus(cassdcapi.DatacenterUpdating)
-	return statusUpdating == corev1.ConditionTrue && cassdc.Status.CassandraOperatorProgress == cassdcapi.ProgressUpdating
+	return nil
 }
 
 func (r *CassandraRestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -377,10 +325,3 @@ func (r *CassandraRestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func deepHashString(obj interface{}) string {
-	hasher := sha256.New()
-	hash.DeepHashObject(hasher, obj)
-	hashBytes := hasher.Sum([]byte{})
-	b64Hash := base64.StdEncoding.EncodeToString(hashBytes)
-	return b64Hash
-}

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -27,7 +27,8 @@ var medusaClientFactory *fakeMedusaClientFactory
 
 const (
 	TestCassandraDatacenterName = "dc1"
-	timeout                     = time.Second * 10
+	requeueAfter                = 2 * time.Second
+	timeout                     = time.Second * 3
 	interval                    = time.Millisecond * 250
 )
 
@@ -76,9 +77,10 @@ func beforeSuite(t *testing.T) {
 	require.NoError(err, "failed to set up CassandraBackupReconciler")
 
 	err = (&CassandraRestoreReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    log.WithName("controllers").WithName("CassandraRestore"),
-		Scheme: scheme.Scheme,
+		Client:       k8sManager.GetClient(),
+		Log:          log.WithName("controllers").WithName("CassandraRestore"),
+		Scheme:       scheme.Scheme,
+		RequeueAfter: requeueAfter,
 	}).SetupWithManager(k8sManager)
 	require.NoError(err, "failed to set up CassandraRestoreReconciler")
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/k8ssandra/medusa-operator/pkg/medusa"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -91,9 +92,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.CassandraRestoreReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("CassandraRestore"),
-		Scheme: mgr.GetScheme(),
+		Client:       mgr.GetClient(),
+		Log:          ctrl.Log.WithName("controllers").WithName("CassandraRestore"),
+		Scheme:       mgr.GetScheme(),
+		RequeueAfter: 10 * time.Second,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CassandraRestore")
 		os.Exit(1)

--- a/pkg/cassandra/util.go
+++ b/pkg/cassandra/util.go
@@ -1,0 +1,27 @@
+package cassandra
+
+import (
+	cassdcapi "github.com/k8ssandra/cass-operator/operator/pkg/apis/cassandra/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"time"
+)
+
+func DatacenterUpdatedAfter(t time.Time, dc *cassdcapi.CassandraDatacenter) bool {
+	updateCondition, found := dc.GetCondition(cassdcapi.DatacenterUpdating)
+	if !found || updateCondition.Status != corev1.ConditionFalse {
+		return false
+	}
+	return updateCondition.LastTransitionTime.After(t)
+}
+
+func DatacenterReady(dc *cassdcapi.CassandraDatacenter) bool {
+	return dc.GetConditionStatus(cassdcapi.DatacenterReady) == corev1.ConditionTrue && dc.Status.CassandraOperatorProgress == cassdcapi.ProgressReady
+}
+
+func DatacenterStopped(dc *cassdcapi.CassandraDatacenter) bool {
+	return dc.GetConditionStatus(cassdcapi.DatacenterStopped) == corev1.ConditionTrue && dc.Status.CassandraOperatorProgress == cassdcapi.ProgressReady
+}
+
+func DatacenterStopping(dc *cassdcapi.CassandraDatacenter) bool {
+	return dc.GetConditionStatus(cassdcapi.DatacenterStopped) == corev1.ConditionTrue && dc.Status.CassandraOperatorProgress == cassdcapi.ProgressUpdating
+}

--- a/pkg/reconcile/requests.go
+++ b/pkg/reconcile/requests.go
@@ -17,19 +17,19 @@ import (
 )
 
 type RestoreRequest struct {
-	Log             logr.Logger
+	Log logr.Logger
 
-	Restore         *api.CassandraRestore
+	Restore *api.CassandraRestore
 
-	Backup          *api.CassandraBackup
+	Backup *api.CassandraBackup
 
-	Datacenter      *cassdcapi.CassandraDatacenter
+	Datacenter *cassdcapi.CassandraDatacenter
 
-	restoreHash     string
+	restoreHash string
 
-	datacenterHash  string
+	datacenterHash string
 
-	restorePatch    client.Patch
+	restorePatch client.Patch
 
 	datacenterPatch client.Patch
 }
@@ -52,7 +52,7 @@ type factory struct {
 func NewFactory(client client.Client, logger logr.Logger) RequestFactory {
 	return &factory{
 		Client: client,
-		Log: logger,
+		Log:    logger,
 	}
 }
 
@@ -93,13 +93,13 @@ func (f *factory) NewRestoreRequest(ctx context.Context, restoreKey types.Namesp
 	datacenterHash := deepHashString(dc.Spec)
 
 	req := RestoreRequest{
-		Log: reqLogger,
-		Restore: restore.DeepCopy(),
-		Backup: backup.DeepCopy(),
-		Datacenter: dc.DeepCopy(),
-		restoreHash: restoreHash,
-		datacenterHash: datacenterHash,
-		restorePatch: client.MergeFromWithOptions(restore.DeepCopy(), client.MergeFromWithOptimisticLock{}),
+		Log:             reqLogger,
+		Restore:         restore.DeepCopy(),
+		Backup:          backup.DeepCopy(),
+		Datacenter:      dc.DeepCopy(),
+		restoreHash:     restoreHash,
+		datacenterHash:  datacenterHash,
+		restorePatch:    client.MergeFromWithOptions(restore.DeepCopy(), client.MergeFromWithOptimisticLock{}),
 		datacenterPatch: client.MergeFromWithOptions(dc.DeepCopy(), client.MergeFromWithOptimisticLock{}),
 	}
 

--- a/pkg/reconcile/requests.go
+++ b/pkg/reconcile/requests.go
@@ -1,0 +1,162 @@
+package reconcile
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"github.com/go-logr/logr"
+	cassdcapi "github.com/k8ssandra/cass-operator/operator/pkg/apis/cassandra/v1beta1"
+	api "github.com/k8ssandra/medusa-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/util/hash"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+type RestoreRequest struct {
+	Log             logr.Logger
+
+	Restore         *api.CassandraRestore
+
+	Backup          *api.CassandraBackup
+
+	Datacenter      *cassdcapi.CassandraDatacenter
+
+	restoreHash     string
+
+	datacenterHash  string
+
+	restorePatch    client.Patch
+
+	datacenterPatch client.Patch
+}
+
+type RequestFactory interface {
+	// NewRestoreRequest Creates and initializes a RestoreRequest. The factory is
+	// responsible for fetching the CassandraRestore, CassandraBackup, and
+	// CassandraDatacenter objects from the api server. The factory returns a deep copy of
+	// each of the objects, so there is no need to call DeepCopy() on them.
+	// Reconciliation should proceed only if the returned Result is nil.
+	NewRestoreRequest(ctx context.Context, restoreKey types.NamespacedName) (*RestoreRequest, *ctrl.Result, error)
+}
+
+type factory struct {
+	client.Client
+
+	Log logr.Logger
+}
+
+func NewFactory(client client.Client, logger logr.Logger) RequestFactory {
+	return &factory{
+		Client: client,
+		Log: logger,
+	}
+}
+
+func (f *factory) NewRestoreRequest(ctx context.Context, restoreKey types.NamespacedName) (*RestoreRequest, *ctrl.Result, error) {
+	restore := &api.CassandraRestore{}
+	err := f.Get(ctx, restoreKey, restore)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, &ctrl.Result{}, nil
+		}
+		f.Log.Error(err, "Failed to get CassandraRestore")
+		return nil, &ctrl.Result{RequeueAfter: 10 * time.Second}, err
+	}
+
+	backup := &api.CassandraBackup{}
+	backupKey := types.NamespacedName{Namespace: restoreKey.Namespace, Name: restore.Spec.Backup}
+	err = f.Get(ctx, backupKey, backup)
+	if err != nil {
+		f.Log.Error(err, "Failed to get CassandraBackup", "CassandraBackup", backupKey)
+		return nil, &ctrl.Result{RequeueAfter: 10 * time.Second}, err
+	}
+
+	dc := &cassdcapi.CassandraDatacenter{}
+	dcKey := types.NamespacedName{Namespace: restoreKey.Namespace, Name: restore.Spec.CassandraDatacenter.Name}
+	err = f.Get(ctx, dcKey, dc)
+	if err != nil {
+		// TODO The datacenter does not have to exist for a remote restore
+		f.Log.Error(err, "Failed to get CassandraDatacenter", "CassandraDatacenter", dcKey)
+		return nil, &ctrl.Result{RequeueAfter: 10 * time.Second}, err
+	}
+
+	reqLogger := f.Log.WithValues(
+		"CassandraRestore", restoreKey,
+		"CassandraBackup", backupKey,
+		"CassandraDatacenter", dcKey)
+
+	restoreHash := deepHashString(restore.Status)
+	datacenterHash := deepHashString(dc.Spec)
+
+	req := RestoreRequest{
+		Log: reqLogger,
+		Restore: restore.DeepCopy(),
+		Backup: backup.DeepCopy(),
+		Datacenter: dc.DeepCopy(),
+		restoreHash: restoreHash,
+		datacenterHash: datacenterHash,
+		restorePatch: client.MergeFromWithOptions(restore.DeepCopy(), client.MergeFromWithOptimisticLock{}),
+		datacenterPatch: client.MergeFromWithOptions(dc.DeepCopy(), client.MergeFromWithOptimisticLock{}),
+	}
+
+	return &req, nil, nil
+}
+
+// RestoreModified returns true if the CassandraRestore.Status has been modified.
+func (r *RestoreRequest) RestoreModified() bool {
+	return deepHashString(r.Restore.Status) != r.restoreHash
+}
+
+// DatacenterModified returns true if the CassandraDatacenter.Spec has been modified.
+func (r *RestoreRequest) DatacenterModified() bool {
+	return deepHashString(r.Datacenter.Spec) != r.datacenterHash
+}
+
+// SetRestoreKey sets the key. Note that this function is idempotent.
+func (r *RestoreRequest) SetRestoreKey(key string) {
+	if len(r.Restore.Status.RestoreKey) == 0 {
+		r.Restore.Status.RestoreKey = key
+	}
+}
+
+// SetRestoreStartTime sets the start time. Note that this function is idempotent.
+func (r *RestoreRequest) SetRestoreStartTime(t metav1.Time) {
+	if r.Restore.Status.StartTime.IsZero() {
+		r.Restore.Status.StartTime = t
+	}
+}
+
+// SetDatacenterStoppedTime sets the stop time.
+func (r *RestoreRequest) SetDatacenterStoppedTime(t metav1.Time) {
+	if r.Restore.Status.DatacenterStopped.IsZero() {
+		r.Restore.Status.DatacenterStopped = t
+	}
+}
+
+func (r *RestoreRequest) SetRestoreFinishTime(time metav1.Time) {
+	r.Restore.Status.FinishTime = time
+}
+
+// GetRestorePatch returns a patch that can be used to apply changes to the CassandraRestore.
+// The patch is created when the RestoreRequest is initialized.
+func (r *RestoreRequest) GetRestorePatch() client.Patch {
+	return r.restorePatch
+}
+
+// GetDatacenterPatch returns a patch that can be used to apply changes to the
+// CassandraDatacenter. The patch is created when the RestoreRequest is initialized.
+func (r *RestoreRequest) GetDatacenterPatch() client.Patch {
+	return r.datacenterPatch
+}
+
+func deepHashString(obj interface{}) string {
+	hasher := sha256.New()
+	hash.DeepHashObject(hasher, obj)
+	hashBytes := hasher.Sum([]byte{})
+	b64Hash := base64.StdEncoding.EncodeToString(hashBytes)
+	return b64Hash
+}


### PR DESCRIPTION
Fixes https://github.com/k8ssandra/k8ssandra/issues/742



┆Issue is synchronized with this [Jira Bug](https://k8ssandra.atlassian.net/browse/K8SSAND-532) by [Unito](https://www.unito.io)

The initial purpose of this PR was to change the restore controller to avoid the unnecessary datacenter rolling restart. The code was a bit of a mess so I decided to take the extra time to refactor it and hopefully improve and simplify it along the way. 

Here is a brief summary of the changes:

* I added a `RestoreRequest` object that stores state for the request and also tracks changes.
* The restore start time in the status is now set immediately.
* The status now has a `DatacenterStopped` timestamp that is used how the start time was previously used. It is used to help determine whether the pod template spec updates have been applied.
* There were several `Patch` and `Update` calls scattered throughout the controller. Those have been consolidated into a single function.

The changes break the integration test; however, the restore testing was incomplete. I already have #47 in progress for replacing Ginkgo. It already has a more complete integration test for restores. I would like to keep the test changes in that PR.

I would like to have a single call to `applyUpdates()` with a `defer` statement. I need to review the code some more to see if that will work.