### PR TITLE
Allow specifying type of backup 'full' or 'differential'

### DIFF
--- a/api/v1alpha1/cassandrabackup_types.go
+++ b/api/v1alpha1/cassandrabackup_types.go
@@ -24,6 +24,14 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// An enum of the possible modes for medusa backups
+type BackupType string
+
+const (
+	FullBackup         BackupType = "full"
+	DifferentialBackup BackupType = "differential"
+)
+
 // CassandraBackupSpec defines the desired state of CassandraBackup
 type CassandraBackupSpec struct {
 	// The name of the backup.
@@ -33,8 +41,10 @@ type CassandraBackupSpec struct {
 	// The name of the CassandraDatacenter to back up
 	CassandraDatacenter string `json:"cassandraDatacenter"`
 
-	//The type of the backup: "full" or "differential"
-	Type string `json:"backupType,omitempty"`
+	// The type of the backup: "full" or "differential"
+	// +kubebuilder:validation:Enum=differential;full;
+	// +kubebuilder:default:=differential
+	Type BackupType `json:"backupType,omitempty"`
 }
 
 type CassandraDatacenterTemplateSpec struct {

--- a/api/v1alpha1/cassandrabackup_types.go
+++ b/api/v1alpha1/cassandrabackup_types.go
@@ -32,6 +32,9 @@ type CassandraBackupSpec struct {
 
 	// The name of the CassandraDatacenter to back up
 	CassandraDatacenter string `json:"cassandraDatacenter"`
+
+	//The type of the backup: "full" or "differential"
+	Type string `json:"backupType,omitempty"`
 }
 
 type CassandraDatacenterTemplateSpec struct {

--- a/config/crd/bases/cassandra.k8ssandra.io_cassandrabackups.yaml
+++ b/config/crd/bases/cassandra.k8ssandra.io_cassandrabackups.yaml
@@ -38,6 +38,9 @@ spec:
               name:
                 description: The name of the backup. TODO document format of generated name
                 type: string
+              backupType:
+                description: The type of the backup, 'full' or 'differential'
+                type: string
             required:
             - cassandraDatacenter
             type: object

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -3,6 +3,11 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+
 	cassdcapi "github.com/k8ssandra/cass-operator/operator/pkg/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/medusa-operator/api/v1alpha1"
 	"github.com/k8ssandra/medusa-operator/pkg/medusa"
@@ -12,11 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"sync"
-	"testing"
 )
 
 func testBackupDatacenter(t *testing.T, ctx context.Context, namespace string) {
@@ -263,7 +264,7 @@ func (c *fakeMedusaClient) Close() error {
 	return nil
 }
 
-func (c *fakeMedusaClient) CreateBackup(ctx context.Context, name string) error {
+func (c *fakeMedusaClient) CreateBackup(ctx context.Context, name string, backupType string) error {
 	c.RequestedBackups = append(c.RequestedBackups, name)
 	return nil
 }

--- a/controllers/cassandrabackup_controller.go
+++ b/controllers/cassandrabackup_controller.go
@@ -283,13 +283,13 @@ func hasMedusaSidecar(pod *corev1.Pod) bool {
 	return false
 }
 
-func doBackup(ctx context.Context, name string, backupType string, pod *corev1.Pod, clientFactory medusa.ClientFactory) error {
+func doBackup(ctx context.Context, name string, backupType api.BackupType, pod *corev1.Pod, clientFactory medusa.ClientFactory) error {
 	addr := fmt.Sprintf("%s:%d", pod.Status.PodIP, backupSidecarPort)
 	if medusaClient, err := clientFactory.NewClient(addr); err != nil {
 		return err
 	} else {
 		defer medusaClient.Close()
-		return medusaClient.CreateBackup(ctx, name, backupType)
+		return medusaClient.CreateBackup(ctx, name, string(backupType))
 	}
 }
 

--- a/controllers/cassandrabackup_controller.go
+++ b/controllers/cassandrabackup_controller.go
@@ -163,7 +163,7 @@ func (r *CassandraBackupReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 			go func() {
 				r.Log.Info("starting backup", "CassandraPod", pod.Name)
 				succeeded := false
-				if err := doBackup(ctx, backup.Spec.Name, &pod, r.ClientFactory); err == nil {
+				if err := doBackup(ctx, backup.Spec.Name, backup.Spec.Type, &pod, r.ClientFactory); err == nil {
 					r.Log.Info("finished backup", "CassandraPod", pod.Name)
 					succeeded = true
 				} else {
@@ -283,13 +283,13 @@ func hasMedusaSidecar(pod *corev1.Pod) bool {
 	return false
 }
 
-func doBackup(ctx context.Context, name string, pod *corev1.Pod, clientFactory medusa.ClientFactory) error {
+func doBackup(ctx context.Context, name string, backupType string, pod *corev1.Pod, clientFactory medusa.ClientFactory) error {
 	addr := fmt.Sprintf("%s:%d", pod.Status.PodIP, backupSidecarPort)
 	if medusaClient, err := clientFactory.NewClient(addr); err != nil {
 		return err
 	} else {
 		defer medusaClient.Close()
-		return medusaClient.CreateBackup(ctx, name)
+		return medusaClient.CreateBackup(ctx, name, backupType)
 	}
 }
 

--- a/pkg/medusa/grpc.go
+++ b/pkg/medusa/grpc.go
@@ -3,6 +3,7 @@ package medusa
 import (
 	"context"
 	"fmt"
+
 	"google.golang.org/grpc"
 
 	"github.com/k8ssandra/medusa-operator/pkg/pb"
@@ -33,7 +34,7 @@ func (f *DefaultFactory) NewClient(address string) (Client, error) {
 type Client interface {
 	Close() error
 
-	CreateBackup(ctx context.Context, name string) error
+	CreateBackup(ctx context.Context, name string, backupType string) error
 
 	GetBackups(ctx context.Context) ([]*pb.BackupSummary, error)
 }
@@ -42,10 +43,15 @@ func (c *defaultClient) Close() error {
 	return c.connection.Close()
 }
 
-func (c *defaultClient) CreateBackup(ctx context.Context, name string) error {
+func (c *defaultClient) CreateBackup(ctx context.Context, name string, backupType string) error {
+	backupMode := pb.BackupRequest_DIFFERENTIAL
+	if backupType == "full" {
+		backupMode = pb.BackupRequest_FULL
+	}
+
 	request := pb.BackupRequest{
 		Name: name,
-		Mode: pb.BackupRequest_DIFFERENTIAL,
+		Mode: backupMode,
 	}
 	_, err := c.grpcClient.Backup(ctx, &request)
 


### PR DESCRIPTION
It looks like the prototype messaging allows specifying the backup type, so this just forwards the request from the helm install command to the medusa instance to allow overriding of the default DIFFERENTIAL backup type.  Comments, criticisms, suggestions very welcome, this is my first PR to k8ssandra, and first time writing GO, please, don't be gentle ;)